### PR TITLE
Tailwind

### DIFF
--- a/react-tailwindcss/.eslintrc.js
+++ b/react-tailwindcss/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: 'eslint: recommended',
+};

--- a/react-tailwindcss/.gitignore
+++ b/react-tailwindcss/.gitignore
@@ -22,3 +22,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# tailwind
+src/style/main.css

--- a/react-tailwindcss/.prettierrc.js
+++ b/react-tailwindcss/.prettierrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  trailingComma: 'all',
+  singleQuote: true,
+  bracketSpacing: true,
+};

--- a/react-tailwindcss/package.json
+++ b/react-tailwindcss/package.json
@@ -21,11 +21,13 @@
     "redux": "^4.0.5"
   },
   "scripts": {
-    "start": "npm run build:css && react-scripts start",
-    "build": "npm run build:css && react-scripts build",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "build:css": "postcss src/style/tailwind.css -o src/style/main.css"
+    "build:css": "postcss src/style/tailwind.css -o src/style/main.css",
+    "prestart": "npm run build:css",
+    "prerun": "npm run build:css"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
apparently tailwind creates the super-long css file itself. I removed it from being tracked by git (it's automatically created anyway) and added basic eslint and prettier config files (eslint will have to be updated to work for typescript and react, coming to think of it)